### PR TITLE
fix: clear user state in logout method of app-facade

### DIFF
--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -1,13 +1,12 @@
-import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
-import { NzMessageService } from 'ng-zorro-antd/message';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
-import { paths } from './app-routing.constants';
-import { LocalStorageService } from './services/local-storage.service';
-import { User, UserData, UserResponse } from './shared/models/User';
-import { AuthService } from './shared/services/auth.service';
-import { UserService } from './shared/services/user.service';
+import { Injectable } from '@angular/core'
+import { Router } from '@angular/router'
+import { NzMessageService } from 'ng-zorro-antd/message'
+import { BehaviorSubject, Observable, of } from 'rxjs'
+import { catchError, map } from 'rxjs/operators'
+import { paths } from './app-routing.constants'
+import { LocalStorageService } from './services/local-storage.service'
+import { User, UserData, UserResponse } from './shared/models/User'
+import { AuthService } from './shared/services/auth.service'
 
 @Injectable({ providedIn: 'root' })
 export class AppFacade {
@@ -73,6 +72,7 @@ export class AppFacade {
     this.auth.logout().subscribe(() => {
       this.lsService.removeItem(this.USER_KEY);
       this.router.navigate([paths.login]);
+      this.user = undefined
     });
   }
 }


### PR DESCRIPTION
now `logout` method of `app-facade` clears local `user` state